### PR TITLE
docs: info.plist: Fix command+return order

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -498,7 +498,7 @@
   read-later-list.
 - Any item in your reading list also shows up when using the keyword `rl`.
 	+ &lt;kbd&gt;⏎&lt;/kbd&gt;: Open the item in your browser and mark it as read.
-	+ &lt;kbd&gt;⏎&lt;/kbd&gt;&lt;kbd&gt;⌘&lt;/kbd&gt;: Mark the item as read.
+	+ &lt;kbd&gt;⌘&lt;/kbd&gt;&lt;kbd&gt;⏎&lt;/kbd&gt;: Mark the item as read.
 
 &gt; [Unfortunately, Firefox is not and cannot be supported.](https://www.alfredforum.com/topic/16748-how-to-do-x-in-firefox-from-alfred/)
 


### PR DESCRIPTION
## Checklist
- [ ] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` and the internal workflow documentation.
